### PR TITLE
Add falling word blocks to play screen

### DIFF
--- a/GameManger.h
+++ b/GameManger.h
@@ -24,6 +24,10 @@ private:
     int currentLevel;
     bool gameRunning;
 
+    // 단어 이동 제어
+    time_t lastWordRenderTime;
+    int wordRenderInterval;
+
     // 점수 계산 상수
     static const int SNOWFLAKE_POINTS = 100;
     static const int TARGET_POINTS = 500;
@@ -34,7 +38,8 @@ public:
     // 생성자
     GameManager(int level) : currentLevel(level), totalScore(0), snowflakeScore(0),
                              targetScore(0), timeBonus(0), levelBonus(0),
-                             gameRunning(false), timeUp(false)
+                             gameRunning(false), timeUp(false),
+                             lastWordRenderTime(0), wordRenderInterval(1)
     {
         // 레벨에 따른 제한시간 설정
         switch (level)
@@ -65,6 +70,7 @@ public:
         targetScore = 0;
         timeBonus = 0;
         levelBonus = currentLevel * LEVEL_BONUS_BASE;
+        lastWordRenderTime = startTime;
     }
 
     // 시간 업데이트 및 카운트다운
@@ -146,6 +152,17 @@ public:
     {
         updateTime();
         return timeUp || !gameRunning;
+    }
+
+    bool shouldUpdateWordBlocks()
+    {
+        time_t now = time(nullptr);
+        if (difftime(now, lastWordRenderTime) >= wordRenderInterval)
+        {
+            lastWordRenderTime = now;
+            return true;
+        }
+        return false;
     }
 
     // 레벨 완료 시 호출

--- a/SentenceManager.cpp
+++ b/SentenceManager.cpp
@@ -1,5 +1,6 @@
 #include "SentenceManager.h"
 #include <algorithm>
+#include <cstdlib>
 
 bool InputHandler::handleInput(int key)
 {
@@ -106,5 +107,53 @@ void SentenceManager::checkAnswers()
         {
             correctMatches++;
         }
+    }
+}
+
+void SentenceManager::createWordBlocks(int maxWidth)
+{
+    wordBlocks.clear();
+    wordAreaWidth = maxWidth;
+    std::srand(static_cast<unsigned int>(std::time(nullptr)));
+
+    int minX = 2;
+    int maxX = wordAreaWidth - 10; // 단어 길이를 고려한 여유 공간
+
+    for (const auto &word : targetWords)
+    {
+        WordBlock block;
+        block.word = word;
+        block.y = 3; // 게임 영역 첫 줄
+        block.x = minX + (std::rand() % std::max(1, maxX - minX));
+        block.active = true;
+        wordBlocks.push_back(block);
+    }
+}
+
+void SentenceManager::advanceWordBlocks(int maxHeight)
+{
+    bool anyActive = false;
+
+    for (auto &block : wordBlocks)
+    {
+        if (!block.active)
+        {
+            continue;
+        }
+
+        anyActive = true;
+        if (block.y < maxHeight)
+        {
+            block.y += 1;
+        }
+        else
+        {
+            block.active = false;
+        }
+    }
+
+    if (!anyActive && wordAreaWidth > 0)
+    {
+        createWordBlocks(wordAreaWidth);
     }
 }

--- a/SentenceManager.h
+++ b/SentenceManager.h
@@ -1,9 +1,18 @@
 #ifndef SENTENCEMANAGER_H
 #define SENTENCEMANAGER_H
 
+#include <ctime>
 #include <string>
 #include <vector>
 #include <ncurses.h>
+
+struct WordBlock
+{
+    std::string word;
+    int x;
+    int y;
+    bool active;
+};
 
 class InputHandler
 {
@@ -43,12 +52,15 @@ private:
     InputHandler *inputHandler;
     std::vector<std::string> targetWords;
     int correctMatches;
+    std::vector<WordBlock> wordBlocks;
+    int wordAreaWidth;
 
 public:
     SentenceManager() : correctMatches(0)
     {
         inputHandler = new InputHandler();
         initializeTargetWords();
+        wordAreaWidth = 0;
     }
 
     ~SentenceManager()
@@ -58,6 +70,10 @@ public:
 
     void initializeTargetWords();
     void checkAnswers();
+    void createWordBlocks(int maxWidth);
+    void advanceWordBlocks(int maxHeight);
+    const std::vector<WordBlock> &getWordBlocks() const { return wordBlocks; }
+
     int getScore() const { return correctMatches * 100; }
 
     InputHandler *getInputHandler() const { return inputHandler; }

--- a/interface.h
+++ b/interface.h
@@ -52,6 +52,7 @@ public:
             init_pair(3, COLOR_WHITE, COLOR_BLACK);  // 눈송이
             init_pair(4, COLOR_RED, COLOR_BLACK);    // 목표물
             init_pair(5, COLOR_CYAN, COLOR_BLACK);   // 점수판
+            init_pair(6, COLOR_GREEN, COLOR_BLACK);  // 단어 블록
         }
 
         // 터미널 크기를 정확히 120x50으로 강제 설정
@@ -67,6 +68,7 @@ public:
         // GameManager 및 SentenceManager 생성
         gameManager = new GameManager(currentLevel);
         sentenceManager = new SentenceManager();
+        sentenceManager->createWordBlocks(gameAreaWidth - 2);
         gameManager->startGame();
     }
 
@@ -89,6 +91,12 @@ public:
 
         // 게임 시간 업데이트
         gameManager->updateTime();
+
+        // 단어 블록 이동 (1초 간격)
+        if (gameManager->shouldUpdateWordBlocks())
+        {
+            sentenceManager->advanceWordBlocks(gameHeight - 3);
+        }
 
         // 게임 종료 조건 확인
         if (gameManager->checkGameEnd())
@@ -284,6 +292,17 @@ public:
 
             mvprintw(row, gameWidth - 1, "|");
         }
+
+        // 단어 블록 렌더링
+        attron(COLOR_PAIR(6) | A_BOLD);
+        for (const auto &block : sentenceManager->getWordBlocks())
+        {
+            if (block.active && block.y >= 3 && block.y < gameHeight - 2)
+            {
+                mvprintw(block.y, block.x, "%s", block.word.c_str());
+            }
+        }
+        attroff(COLOR_PAIR(6) | A_BOLD);
 
         // 하단 (ASCII 문자 사용)
         attron(COLOR_PAIR(1));


### PR DESCRIPTION
## Summary
- add timed word block generation to the sentence manager
- expose 1-second update control in the game manager for falling words
- render animated word blocks in the play screen with a dedicated color

## Testing
- Not run (ncurses environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69252dea4d508330a459282cb2b55142)